### PR TITLE
SpaceMainView외 4개 View Ui및 기능 수정

### DIFF
--- a/DonWorry/DonWorry/DonWorryApp.swift
+++ b/DonWorry/DonWorry/DonWorryApp.swift
@@ -17,8 +17,8 @@ struct DonWorryApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
-            
+//            ContentView()
+            SpaceMainView(spaceID: .constant("12r2334"))
         }
     }
 }

--- a/DonWorry/DonWorry/Extension/ColorExtension.swift
+++ b/DonWorry/DonWorry/Extension/ColorExtension.swift
@@ -60,6 +60,7 @@ extension Color {
     static let cardColor1 = Color(hex: "#401811")
     static let blueA4C6FF = Color(hex: "#A4C6FF")
     static let skyBlue = Color(hex: "#0A84FF")
+    static let paleBlue = Color(hex: "#DFEAFF")
     
 }
 enum CardColor: String, Identifiable, CaseIterable {

--- a/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardDetailView/CardDetailView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardDetailView/CardDetailView.swift
@@ -23,6 +23,7 @@ struct CardDetailView: View {
                         print("ecllipsis FUNCTION")
                     } label: {
                         Image(systemName: "ellipsis")
+                            .font(.system(size: 20, weight: .bold))
                             .foregroundColor(.black)
                     }
                 }.padding(.top, 50)

--- a/DonWorry/DonWorry/Views/SpaceViews/CheckAttendanceView/CheckAttendanceView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/CheckAttendanceView/CheckAttendanceView.swift
@@ -43,7 +43,7 @@ struct CheckAttendanceView: View {
                                     SmallCardView(index: index)
                                 }
                                 .padding(.bottom, index == 4 ? 70 : 0)
-                                //Todo: index는 item개수로 대체 됩니다.
+                                // Todo: index는 item개수로 대체 됩니다.
                             }
                         }
                     }

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceMainBottomButton.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceMainBottomButton.swift
@@ -23,7 +23,7 @@ struct SpaceMainBottomButton: View {
                     .applyTextWithLineLimitModifier(size: textSize, weight: .bold, color: textColor)
                 systemImageString.map {
                     Image(systemName: $0)
-                        .font(Font.system(size: textSize, weight: .light))
+                        .font(Font.system(size: textSize, weight: .bold))
                         .foregroundColor(Color.white)
                 }
             }

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceMainCalculateStartButton.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceMainCalculateStartButton.swift
@@ -20,12 +20,14 @@ struct SpaceMainCalculateStartButton: View {
                     .shadow(radius: 2)
                     .opacity(0.3)
                 VStack(spacing: 10) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(Font.system(size: 36, weight: .ultraLight))
-                        .foregroundColor(Color(hex: "#1c6bff"))
-                        .foregroundColor(.blueMain)
+                    Image(systemName: "checkmark")
+                        .font(Font.system(size: 16, weight: .regular))
+                        .padding(10)
+                        .background(Color.blueMain)
+                        .clipShape(Circle())
+                        .foregroundColor(.white)
                     Text("정산 시작")
-                        .foregroundColor(Color(hex: "#1c6bff"))
+                        .applyTextWithLineLimitModifier(size: 14, weight: .bold, color: .blueMain)
                 }
             }
         }

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceMainCardView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceMainCardView.swift
@@ -45,9 +45,10 @@ struct SpaceMainCardView: View {
                                 .padding(.vertical, 25)
                             Spacer()
                             HStack(spacing: 8) {
-                                (paymentIcon ?? Image("chicken-leg"))
-                                    .applyRectangleImageModifier(width: 27, height: 23, background: .grayEE, innerPadding: 8)
-                                    .padding(.leading, 25)
+                                paymentIcon.map {
+                                    $0.applyRectangleImageModifier(width: 27, height: 23, background: .grayEE, innerPadding: 8)
+                                        .padding(.leading, 25)
+                                }
                                 Text("총 135,800원(4명)")
                                     .applyTextWithLineLimitModifier(size: 18.0, weight: .heavy)
                             }
@@ -106,10 +107,11 @@ struct SpaceMainCardView: View {
         }
     }
 }
+
 struct SpaceMainCardView_Previews: PreviewProvider {
     static var previews: some View {
         SpaceMainCardView(bank: "qwqwqwqwqwqw", color: .blueMain, account: "sdsd", clicked: {
             print("f")
-        }, date: "Sdsd")
+        }, date: "Sdsd",paymentIcon: Image("chicken-leg"))
     }
 }

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceMainCardView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceMainCardView.swift
@@ -41,7 +41,7 @@ struct SpaceMainCardView: View {
                         VStack(alignment: .leading, spacing: 0) {
                             Text(spaceName)
                                 .applyTextWithLineLimitModifier(size: 15, weight: .heavy, color: .white)
-                                .padding(.horizontal, 25)
+                                .padding(.leading, 25)
                                 .padding(.vertical, 25)
                             Spacer()
                             HStack(spacing: 8) {
@@ -59,16 +59,14 @@ struct SpaceMainCardView: View {
                             HStack(alignment: .firstTextBaseline) {
                                 Text(account)
                                     .applyTextWithLineLimitModifier(size: 13, weight: .medium)
-                                Spacer()
                                 Button {
                                     print("copy!")
                                 } label: {
                                     Image(systemName: "doc.on.doc")
                                         .font(Font.system(size: 15, weight: .medium))
                                         .foregroundColor(.white)
-                                        
                                 }
-                                .padding(.trailing, 50)
+                                .padding(.trailing, 25)
                             }
                             .padding(.leading, 25)
                             .padding(.bottom, 16)
@@ -106,5 +104,12 @@ struct SpaceMainCardView: View {
         .onTapGesture {
             clicked()
         }
+    }
+}
+struct SpaceMainCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        SpaceMainCardView(bank: "qwqwqwqwqwqw", color: .blueMain, account: "sdsd", clicked: {
+            print("f")
+        }, date: "Sdsd")
     }
 }

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceTopView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceTopView.swift
@@ -12,6 +12,7 @@ struct SpaceTopView: View {
     let leftPaddingSize = 25.0
     @Binding var spaceID: String
     @State var isAddCardTitleViewShown = false
+    
     var body: some View {
         HStack {
             Text("Space ID : \(spaceID)")
@@ -32,7 +33,7 @@ struct SpaceTopView: View {
             } label: {
                 Text("정산추가")
                     .applyTextWithLineLimitModifier(size: 16.0, weight: .bold, color: .blueMain)
-                    .applyButtonCustomModifier(backgroundColor: Color(hex: "#DFEAFF"), width: 92, height: 26, padding: 4, cornerRadius: 16, strokeLineWith: 0)
+                    .applyButtonCustomModifier(backgroundColor: .paleBlue, width: 92, height: 26, padding: 4, cornerRadius: 16, strokeLineWith: 0)
                     .padding(.trailing, leftPaddingSize)
             }
             NavigationLink(isActive: $isAddCardTitleViewShown) {
@@ -40,11 +41,9 @@ struct SpaceTopView: View {
             } label: {
                 EmptyView()
             }
-
         }
     }
 }
-
 
 struct SpaceTopView_Previews: PreviewProvider {
     static var previews: some View {

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceTopView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceTopView.swift
@@ -15,10 +15,9 @@ struct SpaceTopView: View {
     var body: some View {
         HStack {
             Text("Space ID : \(spaceID)")
-                .applyTextWithLineLimitModifier(size: 14, weight: .bold, color: .black)
+                .applyTextWithLineLimitModifier(size: 14, weight: .regular, color: .black)
                 .opacity(0.5)
                 .padding(.leading, leftPaddingSize)
-            Spacer()
             Button {
                 print("")
             } label: {
@@ -26,6 +25,7 @@ struct SpaceTopView: View {
                     .applyTextWithLineLimitModifier(size: 9, weight: .bold, color: .white)
                     .applyButtonCustomModifier(backgroundColor: .grayC5, width: 47, height: 19, padding: 3)
             }
+            Spacer()
             Button {
                 print("정산추가")
                 isAddCardTitleViewShown = true
@@ -45,10 +45,10 @@ struct SpaceTopView: View {
     }
 }
 
-/*
+
 struct SpaceTopView_Previews: PreviewProvider {
     static var previews: some View {
-        SpaceTopView()
+        SpaceTopView(spaceID: .constant("asdvasdvasdvas"))
     }
 }
- */
+ 

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
@@ -46,7 +46,7 @@ struct SpaceMainView: View {
                                             isModalPresented = true
                                             print("MainCard FUNCTION")
                                             
-                                        }, isParticipated: false, date: "05/05")
+                                        }, isParticipated: false, date: "05/05", paymentIcon: Image("chicken-leg"))
                                     }
                                 }
                             }
@@ -147,7 +147,8 @@ struct SpaceMainView: View {
 
 struct SpaceMainView_Previews: PreviewProvider {
     static var previews: some View {
-        SpaceMainView(spaceID: .constant("Asdasd"))
+//        SpaceMainView(spaceID: .constant("Asdasd"))
+        SpaceMainView(spaceID: .constant("asdasd"))
         
     }
 }

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
@@ -145,7 +145,6 @@ struct SpaceMainView: View {
     }
 }
 
-
 struct SpaceMainView_Previews: PreviewProvider {
     static var previews: some View {
         SpaceMainView(spaceID: .constant("Asdasd"))

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
@@ -34,7 +34,7 @@ struct SpaceMainView: View {
                         ScrollView {
                             SpaceTopView(spaceID: $spaceID)
                                 .padding(.vertical, 21)
-                            LazyVGrid(columns: [GridItem(.fixed(340.0))], spacing: 24) {
+                            LazyVGrid(columns: [GridItem(.fixed(340.0))], spacing: 9) {
                                 ForEach(0..<5) { index in
                                     if index == 4 {
                                         SpaceMainCalculateStartButton(clicked: {
@@ -78,6 +78,10 @@ struct SpaceMainView: View {
                     CardDetailView()
                 })
                 .confirmationDialog("", isPresented: $isShowingDialog, titleVisibility: .hidden) {
+                    
+                                Button("스페이스 초기화") {
+                                    //Todo: 스페이스 초기화 기능
+                                }
                                 Button("스페이스 이름 설정") {
                                     isEditSpaceNaveViewOpened = true
                                 }

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
@@ -57,7 +57,7 @@ struct SpaceMainView: View {
                         SpaceMainBottomButton(text: "링크 공유", systemImageString: "square.and.arrow.up", backgroundColor: .blueMain, textColor: .white) {
                             print("링크 공유 FUNCTION")
                         }
-                        SpaceMainBottomButton(text: "참석 확인", systemImageString: "checkmark", backgroundColor: Color(hex: "#A4C6FF"), textColor: .white) {
+                        SpaceMainBottomButton(text: "참석 확인", systemImageString: "checkmark", backgroundColor: Color(hex: "#A4C6FF"), textColor: .blueMain) {
                             isCheckOutAttendanceViewOpened = true
                             print("참석 확인 FUNCTION")
                         }
@@ -106,13 +106,15 @@ struct SpaceMainView: View {
                             .padding(.leading, 8)
                     }
                     ToolbarItemGroup(placement: .navigationBarTrailing) {
-                        HStack(spacing: leftPaddingSize) {
+                        HStack(spacing: 20) {
                             
                             // Edit Space
                             Button {
                                 isShowingDialog = true
                             } label: {
                                 Image(systemName: "ellipsis")
+                                    .font(.system(size: 20, weight: .bold))
+                                    .foregroundColor(.black)
                             }
                             
                             // Home
@@ -120,6 +122,8 @@ struct SpaceMainView: View {
                                 isHomeView.toggle()
                             } label: {
                                 Image(systemName: "xmark")
+                                    .font(.system(size: 20, weight: .bold))
+                                    .foregroundColor(.black)
                             }.padding(.trailing, 8)
                         }
                     }
@@ -131,11 +135,11 @@ struct SpaceMainView: View {
     }
 }
 
-/*
+
 struct SpaceMainView_Previews: PreviewProvider {
     static var previews: some View {
-        SpaceMainView()
+        SpaceMainView(spaceID: .constant("Asdasd"))
         
     }
 }
- */
+ 


### PR DESCRIPTION
## 개요
SpaceMainView, SpaceTopview, CheckAttendanceView, SpaceMainCalculateStartButton, CardDetailView UI 및 기능 수정입니다.
또한 ColorExtension에 paleBlue 추가했습니다.
관련이슈: https://github.com/DeveloperAcademy-POSTECH/MC2-Team16-Trit/issues/25#issue-1264865970
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
  - [X] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) Fix/Kyu/SpaceMainViewUIFix -> Feat/Merge-UI-Flow

<br/>

## 작업사항 

### 작업 사항
  SpaceMainView - 링크 공유 버튼시 ShareSheetView 나오는 기능추가.
  SpaceMainView - Navigation bar Item bold로 수정
  SpaceTopView - Space id 폰트 regular로 수정
  SpaceTopView - 복사하기 버튼 Space ID 끝나는 자리 옆에, 길어지면 ... 으로 수정.
  SpaceMainView - 링크공유, 참석확인 이모티콘 bold. 참석확인 글자 색깔 파랑색으로 수정.
  SpaceMainCalculateStartButton - 정산 시작 버튼 체크마크 작게, Text font -2, weight bold 으로 수정.
  SpaceMainView - 카드 간 간격 줄이기.
  SpaceMainView - actionSheet에 "스페이스 초기화" 추가.
  CheckAttendanceView - 체크마크 작게, 마지막 동그라미 버튼 위치 버그 수정.
  CardDetailView - eclips icon bold체로 수정.

### 테스트 결과
<p align="left">
<img width="200" alt="스크린샷 2022-06-09 오후 2 53 30" src="https://user-images.githubusercontent.com/77485339/172774280-5d3629b1-ed81-4cc7-95f3-1c93f9005d4c.png">
<img width="200" alt="스크린샷 2022-06-09 오후 2 54 01" src="https://user-images.githubusercontent.com/77485339/172774355-1cf553d2-8207-409f-b7ad-1db00025a904.png">
  <img width="200" alt="화면3" src="https://user-images.githubusercontent.com/77485339/172775667-64d5c15a-928f-4810-b5e8-825f4316acca.png">

- 위는 SpaceMainView, SpaceTopView, SpaceMainCalculateStartButton 수정사항입니다. 
</p>

<p align="left">
<img width="200" alt="스크린샷 2022-06-09 오후 2 53 30" src="https://user-images.githubusercontent.com/77485339/172776333-500d7e2c-d193-4726-8b9a-a4c587036a1f.png">

- 위는 CheckAttendanceView 수정사항입니다. 체크마크가 작아지고, 마지막 인덱스의 원 버튼이 이상한곳에 뜨는것을 수정했습니다.
</p>
<br/>

## 그외
### 리뷰 포인트 
- 반영한 브랜치가 main이 아닌 Feat/Merge-UI-Flow 로 설정 했습니다. 맞을까요?