### PR TITLE
페이지 연결 완료

### DIFF
--- a/DonWorry/DonWorry.xcodeproj/project.pbxproj
+++ b/DonWorry/DonWorry.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2C3C3EA32854946700B29181 /* UserStateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3C3EA22854946700B29181 /* UserStateViewModel.swift */; };
 		2CC211822849F0FA0009F785 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC211812849F0FA0009F785 /* SignInView.swift */; };
 		2CC211842849F1160009F785 /* UserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC211832849F1160009F785 /* UserInfoView.swift */; };
 		2CC211862849F1230009F785 /* TermView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC211852849F1230009F785 /* TermView.swift */; };
@@ -108,6 +109,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2C3C3EA22854946700B29181 /* UserStateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStateViewModel.swift; sourceTree = "<group>"; };
 		2CC211812849F0FA0009F785 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		2CC211832849F1160009F785 /* UserInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoView.swift; sourceTree = "<group>"; };
 		2CC211852849F1230009F785 /* TermView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermView.swift; sourceTree = "<group>"; };
@@ -455,6 +457,7 @@
 				A74479A028476ADA0083BBF4 /* User.swift */,
 				2CC2118B2849F1CF0009F785 /* Term.swift */,
 				A704FC39284DF28900AC9736 /* Alert.swift */,
+				2C3C3EA22854946700B29181 /* UserStateViewModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -813,6 +816,7 @@
 				A704FC3A284DF28900AC9736 /* Alert.swift in Sources */,
 				A704FC33284DDCF700AC9736 /* AlertView.swift in Sources */,
 				4D6229C0284926F600A8E24C /* PhotoPicker.swift in Sources */,
+				2C3C3EA32854946700B29181 /* UserStateViewModel.swift in Sources */,
 				A704FC44284F6B5200AC9736 /* ShareSheet.swift in Sources */,
 				C09C89712849101700E2A929 /* TakerDonCard.swift in Sources */,
 				A74479D8284918EB0083BBF4 /* EditAccountView.swift in Sources */,

--- a/DonWorry/DonWorry/DonWorryApp.swift
+++ b/DonWorry/DonWorry/DonWorryApp.swift
@@ -15,10 +15,26 @@ struct DonWorryApp: App {
     //AppDelegate를 연결합니다.
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
+    @StateObject var userStateViewModel = UserStateViewModel()
+    
     var body: some Scene {
         WindowGroup {
-//            ContentView()
+            NavigationView {
+                ApplicationSwitcher()
+            }
+            .environmentObject(userStateViewModel)
+        }
+    }
+}
+
+struct ApplicationSwitcher: View {
+    @EnvironmentObject var vm: UserStateViewModel
+    
+    var body: some View {
+        if vm.isLoggedIn {
             HomeView(currentUser: user1)
+        } else {
+            SignInView()
         }
     }
 }

--- a/DonWorry/DonWorry/Extension/SignInViewExtension.swift
+++ b/DonWorry/DonWorry/Extension/SignInViewExtension.swift
@@ -55,8 +55,8 @@ extension SignInView {
                    
                     return
                 }
-                log_status = true
-                print(log_status)
+//                log_status = true
+//                print(log_status)
                 print(user.displayName ?? "Success!")
             }
         }

--- a/DonWorry/DonWorry/Models/UserStateViewModel.swift
+++ b/DonWorry/DonWorry/Models/UserStateViewModel.swift
@@ -1,0 +1,22 @@
+//
+//  UserViewStateModel.swift
+//  DonWorry
+//
+//  Created by 김승창 on 2022/06/11.
+//
+
+import Foundation
+
+@MainActor
+class UserStateViewModel: ObservableObject {
+
+    @Published var isLoggedIn = false
+    
+    func signIn() {
+        isLoggedIn = true
+    }
+
+    func signOut() {
+        isLoggedIn = false
+    }
+}

--- a/DonWorry/DonWorry/Views/AuthViews/SignIn/SignInView.swift
+++ b/DonWorry/DonWorry/Views/AuthViews/SignIn/SignInView.swift
@@ -17,92 +17,83 @@ struct SignInView: View {
     
     // SignIn을 위해 선언하였습니다.
     @State var isLoading: Bool = true // 추후 ProgressView를 넣을 것으로 예상하여, 변수를 생성
-    @AppStorage("SignIn Status") var log_status = false // SignIn상태 저장
     @StateObject var appleloginData = AppleLoginViewModel() // Firebase 공식 문서의 가이드라인을 따랐습니다.
     
     var body: some View {
-        
-        if log_status == false { // 이미 로그인된 상태라면 홈뷰로 가도록 했습니다.
-            HomeView(currentUser: user1)
-        } else {
-            NavigationView {
-                ZStack {
-                    LinearGradient(gradient: Gradient(colors: [.white, Color.blueMain]), startPoint: .init(x: 0, y: 0.47), endPoint: .init(x: 0, y: 1))
-                        .ignoresSafeArea()
-
+        ZStack {
+            LinearGradient(gradient: Gradient(colors: [.white, Color.blueMain]), startPoint: .init(x: 0, y: 0.47), endPoint: .init(x: 0, y: 1))
+                .ignoresSafeArea()
+            
+            VStack {
+                VStack(spacing: 15) {
+                    Text("돈.워리")
+                        .foregroundColor(Color.blueMain)
+                        .font(.system(size: 30))
+                        .fontWeight(.bold)
+                    
                     VStack {
-                        VStack(spacing: 15) {
-                            Text("돈.워리")
-                                .foregroundColor(Color.blueMain)
-                                .font(.system(size: 30))
-                                .fontWeight(.bold)
-
-                            VStack {
-                                Text("때인돈 받아드립니다.")
-                                    .fontWeight(.light)
-                                Text("걱정마세요.")
-                                    .fontWeight(.light)
-                            }
-                            .font(.system(size: 15))
-
-                        }
-
-                        Text("")
-                            .frame(height: 120)
-
-                        // 임시로 이미지 클릭하면 다음 페이지로
-                        NavigationLink(destination: UserInfoView()) {
-                            Image("SignInViewImage")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 263)
-
-                        }
-
-                        Text("")
-                            .frame(height: 52)
-
-    //                    VStack(spacing: 10) {
-    //                        ForEach(companies, id: \.self) { company in
-    //                            LoginButtonView(company: company)
-    //                        }
-    //                    }
-                        // MARK: Test용 Button (추후에 UI Design이 수정될 것 같아 임시로 기능 확인을 위해 만들었습니다.)
-                        VStack {
-                            Button {
-                                googleHandleLogin() // Google Social Login function
-                            } label: {
-                                HStack(spacing: 20) {
-                                    Image("Google")
-                                    Text("구글로 로그인하기")
-                                }
-                            }
+                        Text("때인돈 받아드립니다.")
+                            .fontWeight(.light)
+                        Text("걱정마세요.")
+                            .fontWeight(.light)
+                    }
+                    .font(.system(size: 15))
+                    
+                }
                 
-                            // Apple SignIn Butoon 입니다.
-                            // Xcode에서 SignInWithAppleButton이라는 컴포넌트를 지원합니다.
-                            SignInWithAppleButton { (request) in
-                                appleloginData.nonce = randomNonceString()
-                                request.requestedScopes = [.email, .fullName]
-                                request.nonce = sha256(appleloginData.nonce)
-                            } onCompletion: { (result) in
-                                
-                                switch result {
-                                case .success(let user): // 로그인에 성공한 경우
-                                    print("성공")
-                                    guard let credential = user.credential as?
-                                            ASAuthorizationAppleIDCredential else {
-                                        print("Firebase 오류") // credential 생성 성공여부
-                                        return
-                                    }
-                                    appleloginData.authenticate(credential: credential)
-                                    log_status = true
-                                case .failure(let error): // 로그인에 실패한 경우
-                                    print(error.localizedDescription)
-                                }
-                            }.frame(width: 325, height: 70)
-                                .clipShape(Capsule())
+                Text("")
+                    .frame(height: 120)
+                
+                // 임시로 이미지 클릭하면 다음 페이지로
+                NavigationLink(destination: UserInfoView()) {
+                    Image("SignInViewImage")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 263)
+                    
+                }
+                
+                Text("")
+                    .frame(height: 52)
+                
+                //                    VStack(spacing: 10) {
+                //                        ForEach(companies, id: \.self) { company in
+                //                            LoginButtonView(company: company)
+                //                        }
+                //                    }
+                // MARK: Test용 Button (추후에 UI Design이 수정될 것 같아 임시로 기능 확인을 위해 만들었습니다.)
+                VStack {
+                    Button {
+                        googleHandleLogin() // Google Social Login function
+                    } label: {
+                        HStack(spacing: 20) {
+                            Image("Google")
+                            Text("구글로 로그인하기")
                         }
                     }
+                    
+                    // Apple SignIn Butoon 입니다.
+                    // Xcode에서 SignInWithAppleButton이라는 컴포넌트를 지원합니다.
+                    SignInWithAppleButton { (request) in
+                        appleloginData.nonce = randomNonceString()
+                        request.requestedScopes = [.email, .fullName]
+                        request.nonce = sha256(appleloginData.nonce)
+                    } onCompletion: { (result) in
+                        
+                        switch result {
+                        case .success(let user): // 로그인에 성공한 경우
+                            print("성공")
+                            guard let credential = user.credential as?
+                                    ASAuthorizationAppleIDCredential else {
+                                print("Firebase 오류") // credential 생성 성공여부
+                                return
+                            }
+                            appleloginData.authenticate(credential: credential)
+                        case .failure(let error): // 로그인에 실패한 경우
+                            print(error.localizedDescription)
+                        }
+                    }.frame(width: 325, height: 70)
+                        .clipShape(Capsule())
                 }
             }
         }

--- a/DonWorry/DonWorry/Views/AuthViews/TermViews/TermSheetView.swift
+++ b/DonWorry/DonWorry/Views/AuthViews/TermViews/TermSheetView.swift
@@ -14,6 +14,8 @@ struct TermSheetView: View {
         formatter.dateFormat = "YYYY년 M월 d일"
         return formatter
     }
+    
+    @EnvironmentObject var vm: UserStateViewModel
     @Binding var showSheet: Bool
     
     var body: some View {
@@ -46,6 +48,7 @@ struct TermSheetView: View {
             
             Button {
                 showSheet = false
+                vm.signIn()
                 
             } label: {
                 HStack {

--- a/DonWorry/DonWorry/Views/AuthViews/TermViews/TermView.swift
+++ b/DonWorry/DonWorry/Views/AuthViews/TermViews/TermView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct TermView: View {
+    @EnvironmentObject var vm: UserStateViewModel
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
     
     @State private var showSheet = false
@@ -108,6 +109,7 @@ struct TermView: View {
         }
         .halfSheet(showSheet: $showSheet) {
             TermSheetView(agreedTerms: termsOfService.filter { $0.isChecked }, showSheet: $showSheet)
+                .environmentObject(vm)
         } onEnd: {
             showSheet = false
         }

--- a/DonWorry/DonWorry/Views/HomeViews/DonCard/ParticipateDonCard.swift
+++ b/DonWorry/DonWorry/Views/HomeViews/DonCard/ParticipateDonCard.swift
@@ -10,43 +10,43 @@ import SwiftUI
 struct ParticipateDonCard: View {
     // backend에서 참여자들이 다 참가했으면 "상세정산내역보기" 다 참가하지않았으면 "참석확인중"
     @State var isParticipateIn: Bool
-    @Binding var isSpaceView: Bool
-//    @Binding var spaceID: String
+    @Binding var naviSelection: String?
+    //    @Binding var spaceID: String
     
-    var body: some View {  
-        
-        Button {
-            isSpaceView.toggle()
-        } label: {
-            ZStack {
-                BasicRoundRec(color: .blueMain)
-                Circle()
-                    .frame(width: 83, height: 83)
-                    .foregroundColor(Color(hex: "D8D8D8"))
-                    .opacity(0.5)
-                VStack {
-                    Image(systemName: "ellipsis")
-                        .foregroundColor(.white)
-                    .font(.system(size: 30, weight: .bold))
-                    
-                    Spacer().frame(height: 60)
-                    
-                    HStack(alignment: .center, spacing: 5) {
-                        if isParticipateIn == false {
-                            Image(systemName: "arrow.up.backward.and.arrow.down.forward")
-                                .foregroundColor(.white)
-                        }
-                        Text(isParticipateIn ? "참석 확인중" : "상세정산내역보기")
+    var body: some View {
+        NavigationLink(tag: "SpaceMainView", selection: $naviSelection, destination: { SpaceMainView(naviSelection: $naviSelection, spaceID: .constant("Hardcoded ID")) }) {
+            Button {
+                naviSelection = "SpaceMainView"
+            } label: {
+                ZStack {
+                    BasicRoundRec(color: .blueMain)
+                    Circle()
+                        .frame(width: 83, height: 83)
+                        .foregroundColor(Color(hex: "D8D8D8"))
+                        .opacity(0.5)
+                    VStack {
+                        Image(systemName: "ellipsis")
                             .foregroundColor(.white)
-                        .font(.system(size: 16, weight: .bold))
+                        .font(.system(size: 30, weight: .bold))
+                        
+                        Spacer().frame(height: 60)
+                        
+                        HStack(alignment: .center, spacing: 5) {
+                            if isParticipateIn == false {
+                                Image(systemName: "arrow.up.backward.and.arrow.down.forward")
+                                    .foregroundColor(.white)
+                            }
+                            Text(isParticipateIn ? "참석 확인중" : "상세정산내역보기")
+                                .foregroundColor(.white)
+                            .font(.system(size: 16, weight: .bold))
+                        }
                     }
+                    .offset(y: 40)
                 }
-                .offset(y: 40)
             }
         }
     }
 }
-
 
 struct BasicRoundRec: View {
     var color: Color

--- a/DonWorry/DonWorry/Views/HomeViews/DonCard/ParticipateDonCard.swift
+++ b/DonWorry/DonWorry/Views/HomeViews/DonCard/ParticipateDonCard.swift
@@ -45,6 +45,8 @@ struct ParticipateDonCard: View {
                 }
             }
         }
+        .isDetailLink(false)
+
     }
 }
 

--- a/DonWorry/DonWorry/Views/HomeViews/HomeView.swift
+++ b/DonWorry/DonWorry/Views/HomeViews/HomeView.swift
@@ -27,6 +27,8 @@ struct HomeView: View {
                         NavigationLink(destination: ProfileView(),
                                        tag: "ProfileView",
                                        selection: $naviSelection) { EmptyView() }
+                            .isDetailLink(false)
+
                         
                         Button {
                             self.naviSelection = "ProfileView"
@@ -50,6 +52,8 @@ struct HomeView: View {
                     NavigationLink(destination: AlertView(),
                                    tag: "AlertView",
                                    selection: $naviSelection) { EmptyView() }
+                        .isDetailLink(false)
+
                     Button {
                         self.naviSelection = "AlertView"
                     } label: {
@@ -87,6 +91,8 @@ struct HomeView: View {
                     NavigationLink(destination: AddSpaceView(naviSelection: $naviSelection),
                                    tag: "AddSpaceView",
                                    selection: $naviSelection) { EmptyView() }
+                        .isDetailLink(false)
+
                     MediumButton(text: "스페이스 만들기") {
                         self.naviSelection = "AddSpaceView"
                     }
@@ -97,6 +103,8 @@ struct HomeView: View {
             }
             
             NavigationLink(tag: "SpaceMainView", selection: $naviSelection, destination: { SpaceMainView(naviSelection: $naviSelection, spaceID: .constant("Hardcoded ID")) }, label: { EmptyView() })
+                .isDetailLink(false)
+
         }
         .navigationBarHidden(true)
         .slideOverCard(isPresented: $isPresented, onDismiss: {

--- a/DonWorry/DonWorry/Views/HomeViews/HomeView.swift
+++ b/DonWorry/DonWorry/Views/HomeViews/HomeView.swift
@@ -13,127 +13,119 @@ struct HomeView: View {
     @State var selection: String = "떱떱해"
     @State var spaceID: String = ""
     @State var isPresented : Bool = false // Space 입장 ID 입력 Sheet
-    @State var isSpaceView: Bool = false
-    @State private var naviSelection: String? = nil // tag - profile: 로 전환, alert: 로 전환, create: 로 전환
+    
+    @State private var naviSelection: String? = nil // SpaceMainView에서 HomeView로 한번에 dismiss시키기 위한 변수
     
     var currentUser: User
+    
     var body: some View {
-        
-        if isSpaceView == true {
-            
-            SpaceMainView(spaceID: $spaceID)
-            
-        } else {
-            
-            NavigationView {
-                ZStack {
-                    VStack {
-                        HStack {
-                            HStack {
-
-                                NavigationLink(destination: ProfileView(),
-                                               tag: "profile",
-                                               selection: $naviSelection){ EmptyView()}
-                                Button {
-                                    self.naviSelection = "profile"
-                                } label: {
-                                    Image(currentUser.profileImage)
-                                        .resizable()
-                                        .frame(width: 50, height: 50)
-                                        .background(.black)
-                                        .clipShape(Circle())
-                                }
-                                VStack(alignment: .leading) {
-                                    Text(currentUser.userName + "님")
-                                        .font(.system(size: 20, weight: .bold))
-                                    Text("안녕하세요")
-                                        .font(.system(size: 17))
-                                }
-                            }
-                            
-                            Spacer()
-                            
-                            NavigationLink(destination: AlertView(),
-                                           tag: "alert",
-                                           selection: $naviSelection){ EmptyView()}
-                            Button {
-                                self.naviSelection = "alert"
-                            } label: {
-                                Image(systemName: "bell.circle.fill")
-                                    .foregroundColor(.blue)
-                                    .font(.system(size: 40))
-                            }
-                        }
-                        .padding(.bottom, 25)
-                        .padding(.horizontal, 20)
-                        SpaceChipsView(selection: $selection)
-                        Spacer().frame(height: 120)
-                        if currentUser.participant == selection {
-                            ScrollView(.horizontal, showsIndicators: false) {
-                                HStack {
-                                    ParticipateDonCard(isParticipateIn: false, isSpaceView: $isSpaceView)
-                                    
-                                    if currentUser.takeMoney != nil {
-                                        TakerDonCard(currentUser: currentUser)
-                                    }
-                                    if currentUser.giveMoney != nil {
-                                        GiverDonCard(currentUser: currentUser)
-                                    }
-                                }
-                            }
-                        } else {
-                            ParticipateDonCard(isParticipateIn: true, isSpaceView: $isSpaceView)
-                        }
+        ZStack {
+            VStack {
+                HStack {
+                    HStack {
                         
-                        /* Bottom Buttons */
-                        HStack {
-                            XSmallButton(icon: "magnifyingglass") {
-                                isPresented.toggle()
-                            }
-                            NavigationLink(destination: AddSpaceView(),
-                                           tag: "create",
-                                           selection: $naviSelection){ EmptyView()}
-                            MediumButton(text: "스페이스 만들기") {
-                                self.naviSelection = "create"
-                            }
-                        }
-                        .offset(y: 160)
+                        NavigationLink(destination: ProfileView(),
+                                       tag: "ProfileView",
+                                       selection: $naviSelection) { EmptyView() }
                         
-                        Spacer().frame(height: 120)
+                        Button {
+                            self.naviSelection = "ProfileView"
+                        } label: {
+                            Image(currentUser.profileImage)
+                                .resizable()
+                                .frame(width: 50, height: 50)
+                                .background(.black)
+                                .clipShape(Circle())
+                        }
+                        VStack(alignment: .leading) {
+                            Text(currentUser.userName + "님")
+                                .font(.system(size: 20, weight: .bold))
+                            Text("안녕하세요")
+                                .font(.system(size: 17))
+                        }
+                    }
+                    
+                    Spacer()
+                    
+                    NavigationLink(destination: AlertView(),
+                                   tag: "AlertView",
+                                   selection: $naviSelection) { EmptyView() }
+                    Button {
+                        self.naviSelection = "AlertView"
+                    } label: {
+                        Image(systemName: "bell.circle.fill")
+                            .foregroundColor(.blue)
+                            .font(.system(size: 40))
                     }
                 }
-                .navigationBarHidden(true)
-                .slideOverCard(isPresented: $isPresented, onDismiss: {
-                    
-                    isPresented = false
-                    
-                }) {
-                    VStack(alignment: .center, spacing: 25) {
-                        
-                        Image("cash-and-coins")
-                            .resizable()
-                            .frame(width: 100, height: 100)
-                            .padding(.top, 50)
-                        
-                        VStack(spacing: 25) {
-                            Text("스페이스ID로 정산에 참가하기").font(.system(size: 20, weight: .bold))
-                            UnderlineTextField(placeholder: "스페이스 ID를 입력해주세요", charLimit: 20, text: $spaceID)
+                .padding(.bottom, 25)
+                .padding(.horizontal, 20)
+                SpaceChipsView(selection: $selection)
+                Spacer().frame(height: 120)
+                if currentUser.participant == selection {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack {
+                            ParticipateDonCard(isParticipateIn: false, naviSelection: $naviSelection)
+                            
+                            if currentUser.takeMoney != nil {
+                                TakerDonCard(currentUser: currentUser)
+                            }
+                            if currentUser.giveMoney != nil {
+                                GiverDonCard(currentUser: currentUser)
+                            }
                         }
-                        
-                        LargeButton(text: "스페이스 참가하기") {
-                            isPresented = false
-                            isSpaceView.toggle()
-                        }.padding(.bottom, 30)
                     }
-                    .frame(width: 315, height: 350)
+                } else {
+                    ParticipateDonCard(isParticipateIn: true, naviSelection: $naviSelection)
                 }
+                
+                /* Bottom Buttons */
+                HStack {
+                    XSmallButton(icon: "magnifyingglass") {
+                        isPresented.toggle()
+                    }
+                    NavigationLink(destination: AddSpaceView(naviSelection: $naviSelection),
+                                   tag: "AddSpaceView",
+                                   selection: $naviSelection) { EmptyView() }
+                    MediumButton(text: "스페이스 만들기") {
+                        self.naviSelection = "AddSpaceView"
+                    }
+                }
+                .offset(y: 160)
+                
+                Spacer().frame(height: 120)
             }
             
-        }// else
-        
+            NavigationLink(tag: "SpaceMainView", selection: $naviSelection, destination: { SpaceMainView(naviSelection: $naviSelection, spaceID: .constant("Hardcoded ID")) }, label: { EmptyView() })
+        }
+        .navigationBarHidden(true)
+        .slideOverCard(isPresented: $isPresented, onDismiss: {
+            
+            isPresented = false
+            
+        }) {
+            VStack(alignment: .center, spacing: 25) {
+                
+                Image("cash-and-coins")
+                    .resizable()
+                    .frame(width: 100, height: 100)
+                    .padding(.top, 50)
+                
+                VStack(spacing: 25) {
+                    Text("스페이스ID로 정산에 참가하기").font(.system(size: 20, weight: .bold))
+                    UnderlineTextField(placeholder: "스페이스 ID를 입력해주세요", charLimit: 20, text: $spaceID)
+                }
+                
+                LargeButton(text: "스페이스 참가하기") {
+                    isPresented = false
+                    naviSelection = "SpaceMainView"
+                    
+                }.padding(.bottom, 30)
+            }
+            .frame(width: 315, height: 350)
+        }
     }
 }
-
 
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {

--- a/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardDecoView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardDecoView.swift
@@ -28,6 +28,9 @@ enum DecoCase: String, Identifiable, CaseIterable {
 struct AddCardDecoView: View {
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
     
+    
+    @Binding var mainSelection: String? // SpaceMainView로 돌아가기 위한 변수입니다.
+    
     //  추후 데이터 모델이 생성되면 ViewModel을 통해 데이터를 활용할 예정
     //  @StateObject var vm = AddCardDecoViewModel()
     @State private var decoCase: DecoCase = .색상변경
@@ -36,7 +39,6 @@ struct AddCardDecoView: View {
     @State private var images: [UIImage] = []
     @State private var showPhotoPicker = false
     @State private var bank: String = "은행 선택"
-    @State private var isClicked: Bool = false
     @State private var date = Date()
     @State var clickedIndex = 0
     private let colorColumns = [GridItem](repeating: GridItem(spacing: 20), count: 5)
@@ -90,7 +92,9 @@ struct AddCardDecoView: View {
                         text: "완료"
                     ) {
                         print("ChipBtn Clicked!")
-                        isClicked.toggle()
+                        print("전 : \(mainSelection)")
+                        mainSelection = nil
+                        print("후 : \(mainSelection)")
                     }
                 }
             }
@@ -298,7 +302,7 @@ struct CustomPicker: View {
 struct AddCardDecoView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            AddCardDecoView()
+            AddCardDecoView(mainSelection: .constant(""))
         }
     }
 }

--- a/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardIconView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardIconView.swift
@@ -14,17 +14,18 @@ struct AddCardIconView: View {
     
     let paymentTitle: String
     
+    @Binding var mainSelection: String? // SpaceMainView로 돌아가기 위한 변수입니다.
     @State private var paymentIcon : Image? = nil
     @State private var selectedItem: String = ""
-    @State private var naviSelection : String? = nil
+    @State private var naviSelection : String? = nil // 다음 페이지로 이동을 위한 일회성의 변수입니다.
     private let iconColumns = [GridItem](repeating: GridItem(spacing: 10), count: 3)
     
     var body: some View {
         ZStack {
             VStack(alignment: .leading, spacing: 20) {
                 VStack(alignment: .leading) {
-                        Text("정산 내역을")
-                        Text("추가해볼까요?")
+                    Text("정산 내역을")
+                    Text("추가해볼까요?")
                 }
                 .font(.system(size: 25, weight: .bold))
                 .padding(.horizontal, 30)
@@ -60,19 +61,19 @@ struct AddCardIconView: View {
                 }
             }
             
-                        VStack {
-                            Spacer()
-                            NavigationLink(destination: AddCardPriceView(paymentTitle: paymentTitle, paymentIcon: paymentIcon),
-                                           tag: "price",
-                                           selection: $naviSelection) {EmptyView()}
-                            HStack {
-                                Spacer()
-                                SmallButton(text: "다음") {
-                                    self.naviSelection = "price"
-                                }
-                            }
-                            .padding(.horizontal, 30)
-                        }
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    
+                    NavigationLink(tag: "AddCardPriceView", selection: $naviSelection, destination: { AddCardPriceView(mainSelection: $mainSelection, paymentTitle: paymentTitle, paymentIcon: paymentIcon) }) { EmptyView() }
+                        .isDetailLink(false)
+                    SmallButton(text: "다음") {
+                        self.naviSelection = "AddCardPriceView"
+                    }
+                }
+                .padding(.horizontal, 30)
+            }
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -92,6 +93,6 @@ struct AddCardIconView: View {
 
 struct AddCardIconView1_Previews: PreviewProvider {
     static var previews: some View {
-        AddCardIconView(paymentTitle: "땡땡이네 스타벅스")
+        AddCardIconView(paymentTitle: "땡땡이네 스타벅스", mainSelection: .constant(""))
     }
 }

--- a/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardPriceView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardPriceView.swift
@@ -17,8 +17,9 @@ let rows = [
 struct AddCardPriceView: View {
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
     
+    @Binding var mainSelection: String? // SpaceMainView로 돌아가기 위한 변수입니다.
     @State private var price = ""
-    @State private var naviSelection: String? = nil
+    @State private var naviSelection: String? = nil // 다음 페이지로 이동을 위한 일회성의 변수입니다.
     
     var numberPrice: Int {
         Int(price) ?? 0
@@ -37,66 +38,66 @@ struct AddCardPriceView: View {
     }
     
     var body: some View {
-            VStack {
-                HStack {
-                    paymentIcon?
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 37, height: 37)
-                        .background(Color.grayEE)
-                        .cornerRadius(5)
-                    
-                    Text(paymentTitle)
-                        .font(.system(size: 24))
-                        .fontWeight(.bold)
-                    
-                    Spacer()
-                }
-                .padding(.horizontal, 30)
-                .padding(.vertical)
+        VStack {
+            HStack {
+                paymentIcon?
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 37, height: 37)
+                    .background(Color.grayEE)
+                    .cornerRadius(5)
                 
-                HStack(alignment: .bottom) {
-                    Text(price.isEmpty ? "0" : numberFormatter.string(for: numberPrice) ?? "")
-                        .font(.system(size: 50))
-                        .fontWeight(.heavy)
-                    
-                    Text("원")
-                        .font(.system(size: 17))
-                }
+                Text(paymentTitle)
+                    .font(.system(size: 24))
+                    .fontWeight(.bold)
                 
                 Spacer()
-                
-                NavigationLink(destination: AddCardDecoView(paymentIcon: paymentIcon),
-                               tag: "deco",
-                               selection: $naviSelection) {EmptyView()}
-                HStack {
-                    Spacer()
-                    SmallButton(text: "다음") {
-                        self.naviSelection = "deco"
-                    }
-                }
-                .padding(.horizontal, 30)
-                
-                // 숫자 자판
-                VStack {
-                    ForEach(rows, id: \.self) { row in
-                        HStack {
-                            ForEach(row, id: \.self) { column in
-                                Button {
-                                    pressNumber(price, column)
-                                } label: {
-                                    Text(column)
-                                        .font(.system(size: 20, weight: .bold))
-                                        .frame(width: 125, height: 50)
-                                }
-                            }
-                            .padding(.vertical, 17)
-                        }
-                    }
-                }
-                .frame(height: 360, alignment: .top)
-                .background(RoundedRectangle(cornerRadius: 38).stroke(Color.grayF5))
             }
+            .padding(.horizontal, 30)
+            .padding(.vertical)
+            
+            HStack(alignment: .bottom) {
+                Text(price.isEmpty ? "0" : numberFormatter.string(for: numberPrice) ?? "")
+                    .font(.system(size: 50))
+                    .fontWeight(.heavy)
+                
+                Text("원")
+                    .font(.system(size: 17))
+            }
+            
+            Spacer()
+            
+            HStack {
+                Spacer()
+                
+                NavigationLink(tag: "AddCardDecoView", selection: $naviSelection, destination: { AddCardDecoView(mainSelection: $mainSelection) }) { EmptyView() }
+                    .isDetailLink(false)
+                SmallButton(text: "다음") {
+                    self.naviSelection = "AddCardDecoView"
+                }
+            }
+            .padding(.horizontal, 30)
+            
+            // 숫자 자판
+            VStack {
+                ForEach(rows, id: \.self) { row in
+                    HStack {
+                        ForEach(row, id: \.self) { column in
+                            Button {
+                                pressNumber(price, column)
+                            } label: {
+                                Text(column)
+                                    .font(.system(size: 20, weight: .bold))
+                                    .frame(width: 125, height: 50)
+                            }
+                        }
+                        .padding(.vertical, 17)
+                    }
+                }
+            }
+            .frame(height: 360, alignment: .top)
+            .background(RoundedRectangle(cornerRadius: 38).stroke(Color.grayF5))
+        }
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
@@ -140,6 +141,6 @@ struct AddCardPriceView: View {
 
 struct AddCardPriceView_Previews: PreviewProvider {
     static var previews: some View {
-        AddCardPriceView(paymentTitle: "땡땡이네 스타벅스", paymentIcon: Image("chicken-leg"))
+        AddCardPriceView(mainSelection: .constant(""), paymentTitle: "땡땡이네 스타벅스", paymentIcon: Image("chicken-leg"))
     }
 }

--- a/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardTitleView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardTitleView.swift
@@ -10,18 +10,19 @@ import SwiftUI
 struct AddCardTitleView: View {
     
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
+    @Binding var mainSelection: String? // SpaceMainView로 돌아가기 위한 변수입니다.
     @State private var paymentTitle: String = ""
-    @State private var naviSelection: String? = nil
+    @State private var naviSelection: String? = nil // 다음 페이지로 이동을 위한 일회성의 변수입니다.
     
     let maxLength = 15
-     
+    
     var body: some View {
         
         ZStack {
             VStack(alignment: .leading, spacing: 20) {
                 VStack(alignment: .leading) {
-                        Text("정산 내역을")
-                        Text("추가해볼까요?")
+                    Text("정산 내역을")
+                    Text("추가해볼까요?")
                 }
                 .font(.system(size: 25, weight: .bold))
                 .padding(.vertical)
@@ -34,32 +35,32 @@ struct AddCardTitleView: View {
                         .resizable()
                         .frame(width: 250, height: 250)
                         .padding(.top, 30)
-                                               
+                    
                     Spacer()
                     
-// 수정 전
-//                        NavigationLink(destination: AddCardIconView(paymentTitle: paymentTitle)) {
-//                            HStack{
-//                                Text("다음")
-//                                    .frame(width: 135, height: 50)
-//                                    .foregroundColor(.white)
-//                                    .background(paymentTitle.isEmpty ? .blue.opacity(0.3) : .blue)
-//                                    .cornerRadius(29)
-//                            }
-//                        }
-//                        .padding([.leading, .bottom, .trailing], 30)
-//                        .disabled(paymentTitle.isEmpty ? true : false)
+                    // 수정 전
+                    //                        NavigationLink(destination: AddCardIconView(paymentTitle: paymentTitle)) {
+                    //                            HStack{
+                    //                                Text("다음")
+                    //                                    .frame(width: 135, height: 50)
+                    //                                    .foregroundColor(.white)
+                    //                                    .background(paymentTitle.isEmpty ? .blue.opacity(0.3) : .blue)
+                    //                                    .cornerRadius(29)
+                    //                            }
+                    //                        }
+                    //                        .padding([.leading, .bottom, .trailing], 30)
+                    //                        .disabled(paymentTitle.isEmpty ? true : false)
                 }
             }
             VStack {
                 Spacer()
-                NavigationLink(destination: AddCardIconView(paymentTitle: paymentTitle),
-                               tag: "add",
-                               selection: $naviSelection) {EmptyView()}
                 HStack {
                     Spacer()
+                    
+                    NavigationLink(tag: "AddCardIconView", selection: $naviSelection, destination: { AddCardIconView(paymentTitle: paymentTitle, mainSelection: $mainSelection) }) { EmptyView() }
+                        .isDetailLink(false)
                     SmallButton(text: "다음") {
-                        self.naviSelection = "add"
+                        self.naviSelection = "AddCardIconView"
                     }
                 }
                 .padding(.horizontal, 30)
@@ -83,6 +84,6 @@ struct AddCardTitleView: View {
 
 struct NewPayment_Title_Previews: PreviewProvider {
     static var previews: some View {
-        AddCardTitleView()
+        AddCardTitleView(mainSelection: .constant(""))
     }
 }

--- a/DonWorry/DonWorry/Views/SpaceViews/EditSpaceViews/AddSpaceView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/EditSpaceViews/AddSpaceView.swift
@@ -8,62 +8,57 @@
 import SwiftUI
 
 struct AddSpaceView: View {
-    
+    @Binding var naviSelection: String?
     @State var spaceName: String = ""
     @State var isCompleted: Bool = false
+    @State private var pageSelection: String? = nil // 다음 페이지로 이동을 위한 일회성의 변수입니다.
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
     
     var body: some View {
-        
-        if isCompleted == true {
-            SpaceMainView(spaceID: $spaceName)
-        }
-        else {
+        VStack(alignment: .leading, spacing: 20) {
             
-            VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading) {
+                Text("정산 내역을")
+                Text("추가해볼까요?")
+            }
+            .font(.system(size: 25, weight: .bold))
+            .padding(.horizontal, 30)
+            .padding(.vertical)
+            
+            VStack(spacing: 20) {
                 
-                VStack(alignment: .leading) {
-                        Text("정산 내역을")
-                        Text("추가해볼까요?")
-                }
-                .font(.system(size: 25, weight: .bold))
-                .padding(.horizontal, 30)
-                .padding(.vertical)
+                UnderlineTextField(placeholder: "스페이스 이름을 입력하세요", charLimit: 20, text: $spaceName)
                 
-                VStack(spacing: 20) {
-                    
-                    UnderlineTextField(placeholder: "스페이스 이름을 입력하세요", charLimit: 20, text: $spaceName)
-                                               
+                Spacer()
+                
+                HStack {
                     Spacer()
                     
-                    HStack {
-                        Spacer()
-                        
+                    NavigationLink(tag: "SpaceMainView", selection: $pageSelection, destination: { SpaceMainView(naviSelection: $naviSelection, spaceID: .constant("Hardcoded ID")) }) {
                         SmallButton(text: "완료") {
                             isCompleted = true
                         }
                         .padding(.horizontal)
                         .disabled(spaceName.isEmpty ? true : false)
                     }
-                    
+                   
                 }
                 
             }
-            .navigationBarBackButtonHidden(true)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(role: .cancel) {
-                        self.mode.wrappedValue.dismiss()
-                    } label: {
-                        Image(systemName: "chevron.left")
-                            .padding(.horizontal)
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .navigationBarTitleDisplayMode(.inline)
-           
+            
         }
-        
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(role: .cancel) {
+                    self.mode.wrappedValue.dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .padding(.horizontal)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceTopView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/Components/SpaceTopView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct SpaceTopView: View {
     
     let leftPaddingSize = 25.0
+    @Binding var mainSelection: String?
     @Binding var spaceID: String
-    @State var isAddCardTitleViewShown = false
     
     var body: some View {
         HStack {
@@ -27,19 +27,17 @@ struct SpaceTopView: View {
                     .applyButtonCustomModifier(backgroundColor: .grayC5, width: 47, height: 19, padding: 3)
             }
             Spacer()
+            
+            NavigationLink(tag: "AddCardTitleView", selection: $mainSelection, destination: { AddCardTitleView(mainSelection: $mainSelection) }) { EmptyView() }
+            .isDetailLink(false)
+            
             Button {
-                print("정산추가")
-                isAddCardTitleViewShown = true
+                mainSelection = "AddCardTitleView"
             } label: {
                 Text("정산추가")
                     .applyTextWithLineLimitModifier(size: 16.0, weight: .bold, color: .blueMain)
                     .applyButtonCustomModifier(backgroundColor: .paleBlue, width: 92, height: 26, padding: 4, cornerRadius: 16, strokeLineWith: 0)
                     .padding(.trailing, leftPaddingSize)
-            }
-            NavigationLink(isActive: $isAddCardTitleViewShown) {
-                AddCardTitleView()
-            } label: {
-                EmptyView()
             }
         }
     }
@@ -47,7 +45,6 @@ struct SpaceTopView: View {
 
 struct SpaceTopView_Previews: PreviewProvider {
     static var previews: some View {
-        SpaceTopView(spaceID: .constant("asdvasdvasdvas"))
+        SpaceTopView(mainSelection: .constant(""), spaceID: .constant("asdvasdvasdvas"))
     }
 }
- 

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceEmptyView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceEmptyView.swift
@@ -33,7 +33,7 @@ struct SpaceEmptyView: View {
                 ZStack(alignment: .bottom) {
                     VStack {
                         ScrollView {
-                            SpaceTopView(spaceID: $spaceID)
+                            SpaceTopView(mainSelection: .constant(""), spaceID: $spaceID)
                                 .padding(.vertical, 21)
                         }
                     }

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
@@ -33,6 +33,7 @@ struct SpaceMainView: View {
                 ScrollView {
                     SpaceTopView(mainSelection: $mainSelection, spaceID: $spaceID)
                         .padding(.vertical, 21)
+
                     LazyVGrid(columns: [GridItem(.fixed(340.0))], spacing: 9) {
                         ForEach(0..<5) { index in
                             if index == 4 {
@@ -150,4 +151,3 @@ struct SpaceMainView_Previews: PreviewProvider {
         
     }
 }
-

--- a/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/SpaceMainViews/SpaceMainView.swift
@@ -11,7 +11,9 @@ struct SpaceMainView: View {
     
     let leftPaddingSize: CGFloat = 25.0
     
-    @State var isHomeView: Bool = false
+    @Binding var naviSelection: String? // HomeView로 돌아가기 위한 변수입니다.
+    @State private var mainSelection: String? = nil // SpaceMainView로 돌아오기 위한 변수입니다.
+    
     @State var isShowingDialog = false
     @State var isShowingAlert = false
     @State var isModalPresented = false
@@ -26,128 +28,126 @@ struct SpaceMainView: View {
     
     var body: some View {
         
-        if isHomeView == true {
-            HomeView(currentUser: currentUser)
-        } else {
-                ZStack(alignment: .bottom) {
-                    VStack {
-                        ScrollView {
-                            SpaceTopView(spaceID: $spaceID)
-                                .padding(.vertical, 21)
-                            LazyVGrid(columns: [GridItem(.fixed(340.0))], spacing: 9) {
-                                ForEach(0..<5) { index in
-                                    if index == 4 {
-                                        SpaceMainCalculateStartButton(clicked: {
-                                            print("calculate start FUNCTION")
-                                        }) .padding(.bottom, 70)
-                                    } else {
-                                        SpaceMainCardView(bank: "하나은행", color: .blueMain, account: "42910090307", index: index, clicked: {
-                                            isModalPresented = true
-                                            print("MainCard FUNCTION")
-                                            
-                                        }, isParticipated: false, date: "05/05", paymentIcon: Image("chicken-leg"))
-                                    }
-                                }
+        ZStack(alignment: .bottom) {
+            VStack {
+                ScrollView {
+                    SpaceTopView(mainSelection: $mainSelection, spaceID: $spaceID)
+                        .padding(.vertical, 21)
+                    LazyVGrid(columns: [GridItem(.fixed(340.0))], spacing: 9) {
+                        ForEach(0..<5) { index in
+                            if index == 4 {
+                                SpaceMainCalculateStartButton(clicked: {
+                                    print("calculate start FUNCTION")
+                                }) .padding(.bottom, 70)
+                            } else {
+                                SpaceMainCardView(bank: "하나은행", color: .blueMain, account: "42910090307", index: index, clicked: {
+                                    isModalPresented = true
+                                    print("MainCard FUNCTION")
+                                    
+                                }, isParticipated: false, date: "05/05", paymentIcon: Image("chicken-leg"))
                             }
                         }
                     }
-                    .navigationBarTitleDisplayMode(.inline)
-                    
-                    HStack(spacing: 25) {
-                        SpaceMainBottomButton(text: "링크 공유", systemImageString: "square.and.arrow.up", backgroundColor: .blueMain, textColor: .white) {
-                            isShareSheetPresented.toggle()
-                            print("링크 공유 FUNCTION")
-                        }
-                        SpaceMainBottomButton(text: "참석 확인", systemImageString: "checkmark", backgroundColor: Color(hex: "#A4C6FF"), textColor: .blueMain) {
-                            isCheckOutAttendanceViewOpened = true
-                            print("참석 확인 FUNCTION")
-                        }
-                    }
-                    
-                    NavigationLink(isActive: $isCheckOutAttendanceViewOpened) {
-                        CheckAttendanceView()
-                    } label: {
-                        EmptyView()
-                    }
-                    NavigationLink(isActive: $isEditSpaceNaveViewOpened) {
-                        EditSpaceNameView(spaceName: $spaceName)
-                    } label: {
-                        EmptyView()
-                    }
                 }
-                
-                .sheet(isPresented: $isShareSheetPresented, content: {
-                    ShareSheet(items: ["트라잇에서 정산해요!"])
-                })
-                .sheet(isPresented: $isModalPresented, content: {
-                    CardDetailView()
-                })
-                .confirmationDialog("", isPresented: $isShowingDialog, titleVisibility: .hidden) {
-                    
-                                Button("스페이스 초기화") {
-                                    //Todo: 스페이스 초기화 기능
-                                }
-                                Button("스페이스 이름 설정") {
-                                    isEditSpaceNaveViewOpened = true
-                                }
-                                Button("스페이스 삭제") {
-                                    isShowingAlert = true
-                                }
-                                Button("Cancel", role: .cancel) {
-
-                                }
-                           }
-                .alert("스페이스를 삭제하시겠어요?", isPresented: $isShowingAlert, actions: {
-                        Button("삭제", action: {
-                            
-                        })
-                    Button("취소", role: .cancel, action: {
-                        
-                    }).keyboardShortcut(.defaultAction)
-                }, message: {
-                    Text("지금 삭제하시면 현재까지\n등록된 내용이 삭제됩니다.")
-                        .font(.system(size: 13, weight: .regular))
-                })
-                .toolbar {
-                    ToolbarItemGroup(placement: .navigationBarLeading) {
-                        Text(spaceName)
-                            .font(.system(size: 20, weight: .heavy))
-                            .padding(.leading, 8)
-                    }
-                    ToolbarItemGroup(placement: .navigationBarTrailing) {
-                        HStack(spacing: 20) {
-                            
-                            // Edit Space
-                            Button {
-                                isShowingDialog = true
-                            } label: {
-                                Image(systemName: "ellipsis")
-                                    .font(.system(size: 20, weight: .bold))
-                                    .foregroundColor(.black)
-                            }
-                            
-                            // Home
-                            Button {
-                                isHomeView.toggle()
-                            } label: {
-                                Image(systemName: "xmark")
-                                    .font(.system(size: 20, weight: .bold))
-                                    .foregroundColor(.black)
-                            }.padding(.trailing, 8)
-                        }
-                    }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            
+            HStack(spacing: 25) {
+                SpaceMainBottomButton(text: "링크 공유", systemImageString: "square.and.arrow.up", backgroundColor: .blueMain, textColor: .white) {
+                    isShareSheetPresented.toggle()
+                    print("링크 공유 FUNCTION")
                 }
-                .navigationBarTitleDisplayMode(.inline)
-                .navigationBarBackButtonHidden(true)
+                SpaceMainBottomButton(text: "참석 확인", systemImageString: "checkmark", backgroundColor: Color(hex: "#A4C6FF"), textColor: .blueMain) {
+                    isCheckOutAttendanceViewOpened = true
+                    print("참석 확인 FUNCTION")
+                }
+            }
+            
+            NavigationLink(isActive: $isCheckOutAttendanceViewOpened) {
+                CheckAttendanceView()
+            } label: {
+                EmptyView()
+            }
+            .isDetailLink(false)
+            NavigationLink(isActive: $isEditSpaceNaveViewOpened) {
+                EditSpaceNameView(spaceName: $spaceName)
+            } label: {
+                EmptyView()
+            }
+            .isDetailLink(false)
         }
+        
+        .sheet(isPresented: $isShareSheetPresented, content: {
+            ShareSheet(items: ["트라잇에서 정산해요!"])
+        })
+        .sheet(isPresented: $isModalPresented, content: {
+            CardDetailView()
+        })
+        .confirmationDialog("", isPresented: $isShowingDialog, titleVisibility: .hidden) {
+            
+            Button("스페이스 초기화") {
+                // Todo: 스페이스 초기화 기능
+            }
+            Button("스페이스 이름 설정") {
+                isEditSpaceNaveViewOpened = true
+            }
+            Button("스페이스 삭제") {
+                isShowingAlert = true
+            }
+            Button("Cancel", role: .cancel) {
+                
+            }
+        }
+        .alert("스페이스를 삭제하시겠어요?", isPresented: $isShowingAlert, actions: {
+            Button("삭제", action: {
+                
+            })
+            Button("취소", role: .cancel, action: {
+                
+            }).keyboardShortcut(.defaultAction)
+        }, message: {
+            Text("지금 삭제하시면 현재까지\n등록된 내용이 삭제됩니다.")
+                .font(.system(size: 13, weight: .regular))
+        })
+        .toolbar {
+            ToolbarItemGroup(placement: .navigationBarLeading) {
+                Text(spaceName)
+                    .font(.system(size: 20, weight: .heavy))
+                    .padding(.leading, 8)
+            }
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                HStack(spacing: 20) {
+                    
+                    // Edit Space
+                    Button {
+                        isShowingDialog = true
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 20, weight: .bold))
+                            .foregroundColor(.black)
+                    }
+                    
+                    // Home
+                    Button {
+                        naviSelection = nil
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 20, weight: .bold))
+                            .foregroundColor(.black)
+                    }.padding(.trailing, 8)
+                }
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
     }
 }
 
 struct SpaceMainView_Previews: PreviewProvider {
     static var previews: some View {
-//        SpaceMainView(spaceID: .constant("Asdasd"))
-        SpaceMainView(spaceID: .constant("asdasd"))
+        //        SpaceMainView(spaceID: .constant("Asdasd"))
+        SpaceMainView(naviSelection: .constant(""), spaceID: .constant("asdasd"))
         
     }
 }
- 
+


### PR DESCRIPTION
## 개요
페이지들 간 연결 및 NavigationBar가 중첩되는 이슈 해결

### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
  - [ ] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Fix/Asher/AddCardDecoView 브랜치에서 Fix/Charlie/LinkPages 브랜치를 새로 만들어 작업을 완료하였습니다.
Fix/Charlie/LinkPages -> Fix/Asher/AddCardDecoView

<br/>


## 작업 내용
- Models 디렉토리에 UserStateViewModel 파일 추가
- DonWorryApp 파일에 ApplicationSwitcher를 추가하여 로그인, 메인 페이지 플로우 분기
- HomeView -> ParticipateDonCard -> SpaceMainView 연결
- HomeView -> slideOverCard -> SpaceMainView 연결
- HomeView -> AddSpaceView -> SpaceMainView 연결
- SpaceMainView -> AddCardTitleView -> AddCardIconView -> AddCardPriceView -> AddCardDecoView 연결
- 기존에 조건문으로 페이지를 나타내던 코드를 삭제하고 관련된 변수를 삭제하였습니다.
- 가독성을 위해 기존에 있던 NavigationLink의 tag들을 이동하고자 하는 destination 페이지의 이름과 동일하게 바꾸었습니다.


## 페이지 연결 방법
NavigationLink를 통해 페이지를 이동 후 한번에 RootView로 dismiss하는 것이 관건입니다.
공용 컴포넌트로 버튼을 사용하기 때문에 NavigationLink(tag, selection, destination, label)을 사용하였고 버튼이 눌리면 selection을 tag에 맞게 초기화시켜 페이지를 이동할 수 있도록 하였습니다.
RootView에서는 @State 변수를 선언하여 최하위뷰에서 돌아오고자 할 때 이 변수를 nil로 초기화하여 한번에 dismiss시키게끔 하였습니다.
RootView에서 최하위뷰 사이에 위치한 페이지들에서는 그 다음 페이지로 이동을 하기 위해 일회성으로 필요한 @State 변수들을 선언하였습니다.
자세한 내용은 질문을 해주시면 상세히 설명 드리겠습니다.



### References
ex) 작업시 참고한 자료가 있다면 추가해주세요!
  - [Pop to root view][(URL)](https://synapsis9.tistory.com/entry/SwiftUI-Navigation-View-To-Root-네비게이션-뷰-관리하기)
  - [Login / Logout Flow][(URL)](https://paulallies.medium.com/login-logout-flow-swiftui-and-environmentobject-48ea084c5b6e)

## 그외

### 리뷰 포인트
- 컨플릭을 최소화하고자 기존에 있던 변수명은 최대한 건드리지 않았습니다. 대신 변수를 설명하는 주석을 달았습니다.
- 이전 피드백을 반영하여 ContentView를 삭제하지 않았습니다.
- 현재 Fix/Asher/AddCardDecoView 브랜치에서 브랜치를 새로 만들어 작업을 완료했습니다. 페이지 연결하는 코드들이 다른 팀원들이 모두 사용하는 페이지들을 건드리기 때문에 다른 팀원들에게 제가 작성한 코드를 전달하기 위해서는 모두의 코드를 머지하는 과정이 필요한 것으로 보입니다. 관련하여 PM님의 의견이 궁금합니다.
- 플로우 구현 방법 또는 변수명 등이 궁금하면 언제든지 말씀해주세요!