### PR TITLE
Fix : @GestureState를 이용한 스와이프 뒤로가기 기능 제거

### DIFF
--- a/DonWorry/DonWorry/Views/AlertViews/AlertView.swift
+++ b/DonWorry/DonWorry/Views/AlertViews/AlertView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct AlertView: View {
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
-    @GestureState private var dragOffset = false
     
     var body: some View {
         ScrollView {
@@ -60,14 +59,8 @@ struct AlertView: View {
                 Text("알림")
                     .fontWeight(.bold)
                     .font(.system(size: 25))
-                
             }
         }
-        .gesture(DragGesture().updating($dragOffset) { (value, state, transaction) in
-                    if (value.startLocation.x < 30 && value.translation.width > 100) {
-                        self.mode.wrappedValue.dismiss()
-                    }
-                })
     }
 }
 

--- a/DonWorry/DonWorry/Views/AuthViews/TermViews/TermView.swift
+++ b/DonWorry/DonWorry/Views/AuthViews/TermViews/TermView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct TermView: View {
-    @GestureState private var dragOffset = false
     @EnvironmentObject var vm: UserStateViewModel
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
     
@@ -107,11 +106,6 @@ struct TermView: View {
         } onEnd: {
             showSheet = false
         }
-        .gesture(DragGesture().updating($dragOffset) { (value, state, transaction) in
-            if (value.startLocation.x < 30 && value.translation.width > 100) {
-                self.mode.wrappedValue.dismiss()
-            }
-        })
     }
 }
 

--- a/DonWorry/DonWorry/Views/ProfileViews/EditAccountView.swift
+++ b/DonWorry/DonWorry/Views/ProfileViews/EditAccountView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct EditAccountView: View {
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
-    @GestureState private var dragOffset = false
     
     @State private var holder = ""
     @State private var bank = ""
@@ -66,11 +65,6 @@ struct EditAccountView: View {
                 }
                 
             }
-            .gesture(DragGesture().updating($dragOffset) { (value, state, transaction) in
-                if (value.startLocation.x < 30 && value.translation.width > 100) {
-                    self.mode.wrappedValue.dismiss()
-                }
-            })
     }
 }
 

--- a/DonWorry/DonWorry/Views/ProfileViews/EditProfileView.swift
+++ b/DonWorry/DonWorry/Views/ProfileViews/EditProfileView.swift
@@ -8,7 +8,6 @@ import SwiftUI
 
 struct EditProfileView: View {
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
-    @GestureState private var dragOffset = false
     
     @State private var name = ""
     @FocusState private var isFocused: Bool
@@ -62,11 +61,6 @@ struct EditProfileView: View {
             }
             
         }
-        .gesture(DragGesture().updating($dragOffset) { (value, state, transaction) in
-            if (value.startLocation.x < 30 && value.translation.width > 100) {
-                self.mode.wrappedValue.dismiss()
-            }
-        })
     }
 }
 

--- a/DonWorry/DonWorry/Views/ProfileViews/ProfileView.swift
+++ b/DonWorry/DonWorry/Views/ProfileViews/ProfileView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 struct ProfileView: View {
     
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
-    @GestureState private var dragOffset = false
     
     var nickName = "동에번쩍"
     var userName = "홍길동"
@@ -169,11 +168,6 @@ struct ProfileView: View {
             }
             
         }
-        .gesture(DragGesture().updating($dragOffset) { (value, state, transaction) in
-            if (value.startLocation.x < 30 && value.translation.width > 100) {
-                self.mode.wrappedValue.dismiss()
-            }
-        })
     }
 }
 

--- a/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardDecoView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardDecoView.swift
@@ -27,7 +27,6 @@ enum DecoCase: String, Identifiable, CaseIterable {
 
 struct AddCardDecoView: View {
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
-    @GestureState private var dragOffset = false
     @Binding var mainSelection: String? // SpaceMainView로 돌아가기 위한 변수입니다.
     
     //  추후 데이터 모델이 생성되면 ViewModel을 통해 데이터를 활용할 예정
@@ -140,11 +139,6 @@ struct AddCardDecoView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .gesture(DragGesture().updating($dragOffset) { (value, state, transaction) in
-            if (value.startLocation.x < 30 && value.translation.width > 100) {
-                self.mode.wrappedValue.dismiss()
-            }
-        })
     }
     
     // MARK: 컬러박스 입력 칸

--- a/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardIconView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardIconView.swift
@@ -11,7 +11,6 @@ let iconsArray = ["apple-1", "birthday-cake", "blue-car", "camera-icon", "chicke
 
 struct AddCardIconView: View {
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
-    @GestureState private var dragOffset = false
     
     let paymentTitle: String
     
@@ -88,11 +87,6 @@ struct AddCardIconView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .gesture(DragGesture().updating($dragOffset) { (value, state, transaction) in
-            if (value.startLocation.x < 30 && value.translation.width > 100) {
-                self.mode.wrappedValue.dismiss()
-            }
-        })
     }
 }
 

--- a/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardPriceView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardPriceView.swift
@@ -16,7 +16,6 @@ let rows = [
 
 struct AddCardPriceView: View {
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
-    @GestureState private var dragOffset = false
     @Binding var mainSelection: String? // SpaceMainView로 돌아가기 위한 변수입니다.
     @State private var price = ""
     @State private var naviSelection: String? = nil // 다음 페이지로 이동을 위한 일회성의 변수입니다.
@@ -113,11 +112,6 @@ struct AddCardPriceView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .gesture(DragGesture().updating($dragOffset) { (value, state, transaction) in
-            if (value.startLocation.x < 30 && value.translation.width > 100) {
-                self.mode.wrappedValue.dismiss()
-            }
-        })
     }
     
     func pressNumber(_ price: String, _ input: String) {

--- a/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardTitleView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/CardViews/CardCreationView/AddCardTitleView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct AddCardTitleView: View {
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
-    @GestureState private var dragOffset = false
     @Binding var mainSelection: String? // SpaceMainView로 돌아가기 위한 변수입니다.
     @State private var paymentTitle: String = ""
     @State private var naviSelection: String? = nil // 다음 페이지로 이동을 위한 일회성의 변수입니다.
@@ -80,11 +79,6 @@ struct AddCardTitleView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .gesture(DragGesture().updating($dragOffset) { (value, state, transaction) in
-            if (value.startLocation.x < 30 && value.translation.width > 100) {
-                self.mode.wrappedValue.dismiss()
-            }
-        })
     }
 }
 

--- a/DonWorry/DonWorry/Views/SpaceViews/EditSpaceViews/AddSpaceView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/EditSpaceViews/AddSpaceView.swift
@@ -13,7 +13,6 @@ struct AddSpaceView: View {
     @State private var pageSelection: String? = nil // 다음 페이지로 이동을 위한 일회성의 변수입니다.
     @FocusState private var isFocused: Bool
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
-    @GestureState private var dragOffset = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -71,10 +70,5 @@ struct AddSpaceView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .gesture(DragGesture().updating($dragOffset) { (value, state, transaction) in
-                    if (value.startLocation.x < 30 && value.translation.width > 100) {
-                        self.mode.wrappedValue.dismiss()
-                    }
-                })
     }
 }

--- a/DonWorry/DonWorry/Views/SpaceViews/EditSpaceViews/EditSpaceNameView.swift
+++ b/DonWorry/DonWorry/Views/SpaceViews/EditSpaceViews/EditSpaceNameView.swift
@@ -11,7 +11,6 @@ struct EditSpaceNameView: View {
     
     @Binding var spaceName: String
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
-    @GestureState private var dragOffset = false
     @FocusState private var isFocused: Bool
     
     var body: some View {
@@ -54,11 +53,6 @@ struct EditSpaceNameView: View {
                 }
             }
         }
-        .gesture(DragGesture().updating($dragOffset) { (value, state, transaction) in
-            if (value.startLocation.x < 30 && value.translation.width > 100) {
-                self.mode.wrappedValue.dismiss()
-            }
-        })
     }
 }
 


### PR DESCRIPTION
## 개요
스와이프 기능 중복으로 인해 하나를 제거하였습니다.

### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
  - [ ] 기능 추가
  - [X] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/Avery/login -> main
origin/Charlie/DeleteGesture -> origin/main

<br/>

## 작업사항 
### 작업 사항
AddCardTitleView, AddCardIconView, AddCardPriceView, AddCardDecoView, EditSpaceNameView, AddSpaceView, AlertView, ProfileView, EditProfileView, EditAccountView, TermView 페이지에서 @GestureState 변수와 관련한 gesture를 삭제하였습니다.